### PR TITLE
Add UI to manage Wiki categories

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,6 +39,7 @@ Written in 2016-2016 by Sam Hamilton - samhamilton
 Written in 2016-2016 by Jens Hardings - jenshp
 Written in 2016-2016 by Michal Rovnanik - mrovnanik
 Written in 2017-2017 by Sean Lovinger - smlovin2
+Written in 2017-2017 by Oleg Andrieiev - oandreyev
 
 ===========================================================================
 
@@ -65,3 +66,4 @@ Written in 2016-2016 by Sam Hamilton - samhamilton
 Written in 2016-2017 by Jens Hardings - jenshp
 Written in 2016-2016 by Michal Rovnanik - mrovnanik
 Written in 2017-2017 by Sean Lovinger - smlovin2
+Written in 2017-2017 by Oleg Andrieiev - oandreyev

--- a/screen/SimpleScreens/Wiki/wiki.xml
+++ b/screen/SimpleScreens/Wiki/wiki.xml
@@ -53,6 +53,11 @@ along with this software (see the LICENSE.md file). If not, see
     <transition name="addComment"><service-call name="mantle.party.CommunicationServices.add#WikiPageComment"/>
         <default-response url="."/></transition>
 
+    <transition name="addCategory"><service-call name="create#WikiPageCategoryMember"/>
+        <default-response url="."/></transition>
+    <transition name="removeCategory"><service-call name="delete#WikiPageCategoryMember"/>
+        <default-response url="."/></transition>
+
     <pre-actions>
         <set field="extraPathNameList" from="sri.screenUrlInfo.extraPathNameList"/>
         <if condition="extraPathNameList &amp;&amp; extraPathNameList[0] == 'apps'"><return/></if>
@@ -88,6 +93,11 @@ along with this software (see the LICENSE.md file). If not, see
         <!-- Comments -->
         <entity-find entity-name="mantle.party.communication.WikiPageCommEventDetail" list="commEventDetailList">
             <econdition field-name="wikiPageId"/><order-by field-name="entryDate"/></entity-find>
+
+        <!-- Wike categories -->
+        <entity-find entity-name="moqui.resource.wiki.WikiPageCategory" list="wikiPageCategories">
+            <order-by field-name="categoryName"/>
+        </entity-find>
     </actions>
 
     <widgets>
@@ -158,6 +168,47 @@ along with this software (see the LICENSE.md file). If not, see
                     <!-- TODO: add delete link; maybe just move to a _trash directory? -->
                 </widgets></section-iterate>
             </box-body></container-box>
+
+            <section name="CategoriesSection" condition="wikiPageCategories">
+                <actions>
+                    <entity-find entity-name="moqui.resource.wiki.WikiPageCategoryMember" list="membershipList">
+                        <econdition field-name="wikiPageId" from="wikiPageId"/>
+                    </entity-find>
+                </actions>
+                <widgets>
+                    <container-box>
+                        <box-header>
+                            <label text="Categories" type="h5"/>
+                        </box-header>
+                        <box-toolbar>
+                            <container-dialog id="AddCategoryDialog" button-text="Add Category" >
+                                <form-single name="AddCategory" transition="addCategory">
+                                    <field name="wikiPageId"><default-field><hidden/></default-field></field>
+                                    <field name="wikiPageCategoryId">
+                                        <default-field title="Category">
+                                            <drop-down>
+                                                <list-options list="wikiPageCategories" text="${categoryName}" key="${wikiPageCategoryId}"/>
+                                            </drop-down>
+                                        </default-field>
+                                    </field>
+                                    <field name="submitButton"><default-field title="Add"><submit/></default-field></field>
+                                </form-single>
+                            </container-dialog>
+                        </box-toolbar>
+                        <box-body>
+                            <form-list name="CategoriesForm" list="membershipList" transition="removeCategory" skip-header="true">
+                                <field name="wikiPageId"><default-field><hidden/></default-field></field>
+                                <field name="wikiPageCategoryId">
+                                    <default-field title="">
+                                        <display-entity entity-name="moqui.resource.wiki.WikiPageCategory" text="${categoryName}"/>
+                                    </default-field>
+                                </field>
+                                <field name="submitButton" align="right"><default-field title=""><submit icon="glyphicon glyphicon-remove"/></default-field></field>
+                            </form-list>
+                        </box-body>
+                    </container-box>
+                </widgets>
+            </section>
 
             <section name="PageRelatedSection" condition="wikiPageId"><actions>
                 <entity-find entity-name="mantle.request.WikiPageAndRequest" list="wparList">


### PR DESCRIPTION
This is UI that make possible assign categories to a Wiki page. I put container-box under attachments in the left column.

I don't like how button Add Category overlaps the box title but actually, I did not find a way to make the title of popup window different than button label but just "Add" in dialog header I like even less. 

