### PR TITLE
Changed commented notificationMessageId field to hidden instead.

### DIFF
--- a/screen/MyAccount/User/Notifications.xml
+++ b/screen/MyAccount/User/Notifications.xml
@@ -64,7 +64,7 @@ along with this software (see the LICENSE.md file). If not, see
                 <conditional-field condition="linkText"><link url="${linkText}" text="${titleText}" link-type="anchor" style="${typeString ? 'text-' + typeString : ''}"/></conditional-field>
                 <default-field><label text="${titleText}" style="${typeString ? 'text-' + typeString : ''}"/></default-field>
             </field>
-            <!-- <field name="notificationMessageId"><default-field title="ID"><display/></default-field></field> -->
+            <field name="notificationMessageId"><default-field title="ID"><hidden/></default-field></field>
             <field name="topic">
                 <header-field show-order-by="true"><drop-down allow-empty="true">
                     <list-options list="notificationTopicList" key="${topic}" text="${description}"/>


### PR DESCRIPTION
Marking notifications as viewed was not working because no notificationMessageId was sent.