### PR TITLE
Wiki blog - screens

### DIFF
--- a/screen/SimpleScreens/Wiki/EditWikiBlog.xml
+++ b/screen/SimpleScreens/Wiki/EditWikiBlog.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This software is in the public domain under CC0 1.0 Universal plus a
+Grant of Patent License.
+
+To the extent possible under law, the author(s) have dedicated all
+copyright and related and neighboring rights to this software to the
+public domain worldwide. This software is distributed without any
+warranty.
+
+You should have received a copy of the CC0 Public Domain Dedication
+along with this software (see the LICENSE.md file). If not, see
+<http://creativecommons.org/publicdomain/zero/1.0/>.
+-->
+<screen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/xml-screen-2.1.xsd"
+        default-menu-title="Wiki Blog Post" default-menu-index="1">
+
+    <parameter name="wikiBlogId"/>
+
+    <transition name="createBlog">
+        <service-call name="org.moqui.impl.WikiServices.create#WikiBlog" in-map="context"/>
+        <default-response url="../WikiBlogs"/><error-response url="."/>
+    </transition>
+    <transition name="updateBlog">
+        <service-call name="org.moqui.impl.WikiServices.update#WikiBlog" in-map="context"/>
+        <default-response url="."><parameter name="wikiBlogId" from="wikiBlogId"/></default-response>
+        <error-response url="."/>
+    </transition>
+
+    <actions>
+        <set field="isCreate" from="!wikiBlogId"/>
+        <if condition="wikiBlogId">
+            <entity-find-one entity-name="moqui.resource.wiki.WikiBlog" value-field="wikiBlog"/>
+
+            <if condition="wikiBlog.blogLocation">
+                <service-call name="org.moqui.impl.WikiServices.get#WikiPageInfo" out-map="context"
+                        in-map="[wikiSpaceId:wikiBlog.wikiSpaceId, pagePath:wikiBlog.blogLocation]"/>
+                <set field="blogText" from="pageReference?.text"/>
+            </if>
+        </if>
+    </actions>
+
+    <widgets>
+        <container><label text="${isCreate ? 'Create Blog' : 'Edit Blog'}" type="h3"/></container>
+        <form-single name="EditBlogForm" map="wikiBlog" transition="${isCreate?'createBlog':'updateBlog'}">
+            <field name="wikiBlogId"><default-field><hidden /></default-field></field>
+            <field name="wikiSpaceId"><conditional-field condition="isCreate">
+                <drop-down>
+                    <entity-options key="${wikiSpaceId}" text="${wikiSpaceId}">
+                        <entity-find entity-name="moqui.resource.wiki.WikiSpace">
+                            <order-by field-name="wikiSpaceId"/>
+                        </entity-find>
+                    </entity-options>
+                </drop-down>
+                </conditional-field>
+                <default-field><hidden /></default-field>
+            </field>
+            <field name="title">
+                <conditional-field condition="isCreate"><text-line size="120"/></conditional-field>
+                <default-field><display also-hidden="true" /></default-field>
+            </field>
+            <field name="publishDate"><default-field><date-time type="date" /></default-field></field>
+            <field name="author"><default-field><text-line size="60"/></default-field></field>
+            <field name="metaKeywords"><default-field><text-line size="120"/></default-field></field>
+            <field name="metaDescription"><default-field><text-area cols="120" rows="2" maxlength="160"/></default-field></field>
+            <field name="smallImage"><default-field><file /></default-field></field>
+            <field name="blogText"><default-field><text-area cols="120" rows="35"/></default-field></field>
+            <field name="submitButton"><default-field title="Post"><submit/></default-field></field>
+        </form-single>
+        <section name="HtmlEditorSection">
+            <widgets>
+                <render-mode><text type="html"><![CDATA[
+                    <script src="https://cdn.ckeditor.com/4.7.3/full/ckeditor.js" type="text/javascript"></script>
+                    <script src="https://cdn.ckeditor.com/4.7.3/full/adapters/jquery.js" type="text/javascript"></script>
+                    <script>CKEDITOR.dtd.$removeEmpty['i'] = false;
+                    $('#EditBlogForm_blogText').ckeditor({ allowedContent:true, linkJavaScriptLinksAllowed:true, fillEmptyBlocks:false,
+                        extraAllowedContent:'p(*)[*]{*};div(*)[*]{*};li(*)[*]{*};ul(*)[*]{*};i(*)[*]{*};span(*)[*]{*}',
+                        width:'100%', height:'600px', removeButtons:'Save,NewPage,Preview' }).editor.on('change', function(evt) { this.updateElement(); });</script>
+                    ]]></text>
+                </render-mode>
+            </widgets>
+        </section>
+    </widgets>
+</screen>

--- a/screen/SimpleScreens/Wiki/WikiBlogs.xml
+++ b/screen/SimpleScreens/Wiki/WikiBlogs.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This software is in the public domain under CC0 1.0 Universal plus a
+Grant of Patent License.
+
+To the extent possible under law, the author(s) have dedicated all
+copyright and related and neighboring rights to this software to the
+public domain worldwide. This software is distributed without any
+warranty.
+
+You should have received a copy of the CC0 Public Domain Dedication
+along with this software (see the LICENSE.md file). If not, see
+<http://creativecommons.org/publicdomain/zero/1.0/>.
+-->
+<screen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/xml-screen-2.1.xsd"
+        default-menu-title="Wiki Blogs" default-menu-include="false">
+
+    <pre-actions><set field="html_title" value="Find Wiki Blog"/></pre-actions>
+
+    <actions>
+        <entity-find entity-name="moqui.resource.wiki.WikiBlog" list="blogsList">
+            <search-form-inputs default-order-by="publishDate DESC"/></entity-find>
+    </actions>
+
+    <widgets>
+        <container>
+            <link text="New Post" url="../EditWikiBlog" link-type="anchor-button"/>
+        </container>
+        <form-list name="WikiBlogList" list="blogsList" skip-form="true" header-dialog="true" saved-finds="true">
+            <field name="wikiBlogId"><default-field title="View">
+                <link url="../EditWikiBlog" text="View">
+                    <parameter name="wikiBlogId"/>
+                </link>
+            </default-field></field>
+            <field name="title"><header-field show-order-by="case-insensitive"><text-find /></header-field>
+                <default-field><display also-hidden="false"/></default-field></field>
+            <field name="author"><header-field show-order-by="case-insensitive">
+                <drop-down allow-empty="true">
+                    <entity-options text="${author}" key="${author}">
+                        <entity-find entity-name="moqui.resource.wiki.WikiBlog" distinct="true">
+                            <select-field field-name="author"/>
+                        </entity-find>
+                        </entity-options>
+                </drop-down></header-field>
+                <default-field><display also-hidden="false"/></default-field></field>
+            <field name="publishDate"><header-field show-order-by="case-insensitive"><date-find type="date" /></header-field>
+                <default-field><display format="yyyy-MM-dd" /></default-field>
+            </field>
+
+            <field name="findButton"><header-field title="Find"><submit/></header-field></field>
+        </form-list>
+    </widgets>
+</screen>

--- a/screen/SimpleScreens/Wiki/WikiSpaces.xml
+++ b/screen/SimpleScreens/Wiki/WikiSpaces.xml
@@ -14,7 +14,7 @@ along with this software (see the LICENSE.md file). If not, see
 -->
 <screen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/xml-screen-2.1.xsd"
-        default-menu-include="false">
+        default-menu-title="Wiki Spaces" default-menu-include="false">
 
     <transition name="createSpace"><service-call name="org.moqui.impl.WikiServices.create#WikiSpace" in-map="context"/>
         <default-response url="."/></transition>


### PR DESCRIPTION
Menu for wiki blog should appear under Wiki/Content. See screenshot. New Post creates a new record in WikiBlog entity and new wiki page under the root of selected space. I think some seed data would be useful for testing. Please load
```
<moqui.resource.wiki.WikiSpace wikiSpaceId="RCHBLOG" description="Blogs articles" restrictView="N" allowAnyHtml="Y"
        rootPageLocation="dbresource://RidgeCrest/rchblog/content.html" decoratorScreenLocation=""/>
<moqui.resource.wiki.WikiPage wikiPageId="rch_blog" wikiSpaceId="RCHBLOG" pagePath="">
    <histories historySeqId="01" versionName="01" changeDateTime="1485028800000"/>
</moqui.resource.wiki.WikiPage>
    
<moqui.resource.DbResource filename="Blogs.html" isFile="Y" resourceId="rch_blogs" parentResourceId="rch_content_dir">
    <file mimeType="text/html" versionName="01" rootVersionName="01">
        <fileData><![CDATA[
            <h3>Blog Posts</h3>
        ]]></fileData>
    </file>
    <histories versionName="01" versionDate="2017-03-01 00:00:00.000" isDiff="N"/>
</moqui.resource.DbResource>
<moqui.resource.wiki.WikiPage wikiPageId="rch_blogs" wikiSpaceId="RCHERBALS" pagePath="Blogs" publishedVersionName="01">
    <histories historySeqId="01" versionName="01" changeDateTime="1485028800000"/>
</moqui.resource.wiki.WikiPage>
<moqui.resource.DbResource filename="Blogs" isFile="N" resourceId="rch_blogs_dir" parentResourceId="rch_content_dir"/>
```

Related pull requests are posted to mantle-udm and mantle-usl .

Screenshots of the screens.

<img width="1434" alt="wblog_list" src="https://user-images.githubusercontent.com/2572318/31399506-3c960280-adf5-11e7-802d-754ee56ebb57.png">

and edit form

<img width="1432" alt="wblog_view" src="https://user-images.githubusercontent.com/2572318/31399515-428e5282-adf5-11e7-9e07-54f423b3e7f0.png">

A small image can be uploaded but nothing appears if we open an existing post. This should be implemented later.