### PR TITLE
Wiki Blog - use wikiPageId instead of blogLocation to find proper page

### DIFF
--- a/screen/SimpleScreens/Wiki/EditWikiBlog.xml
+++ b/screen/SimpleScreens/Wiki/EditWikiBlog.xml
@@ -32,9 +32,9 @@ along with this software (see the LICENSE.md file). If not, see
         <if condition="wikiBlogId">
             <entity-find-one entity-name="moqui.resource.wiki.WikiBlog" value-field="wikiBlog"/>
 
-            <if condition="wikiBlog.blogLocation">
+            <if condition="wikiBlog.wikiPageId">
                 <service-call name="org.moqui.impl.WikiServices.get#WikiPageInfo" out-map="context"
-                        in-map="[wikiSpaceId:wikiBlog.wikiSpaceId, pagePath:wikiBlog.blogLocation]"/>
+                        in-map="[wikiSpaceId:wikiBlog.wikiSpaceId, wikiPageId:wikiBlog.wikiPageId]"/>
                 <set field="blogText" from="pageReference?.text"/>
             </if>
         </if>


### PR DESCRIPTION
Required after changes in the entity.