### PR TITLE
Fix in ShipmentDetail for duplicated section name

### DIFF
--- a/screen/SimpleScreens/Shipment/ShipmentDetail.xml
+++ b/screen/SimpleScreens/Shipment/ShipmentDetail.xml
@@ -330,7 +330,7 @@ along with this software (see the LICENSE.md file). If not, see
                     <link url="deliverShipment" text="Set Delivered" confirmation="Set to Delivered? No additional items may be received once Delivered" condition="isTransfer"/>
                 </fail-widgets></section>
             </widgets></section>
-            <section name="ShipShippedSection" condition="shipment.statusId == 'ShipDelivered'"><widgets>
+            <section name="ShipDeliveredSection" condition="shipment.statusId == 'ShipDelivered'"><widgets>
                 <link url="shipShipment" text="Set Shipped (Un-deliver)"/>
             </widgets></section>
             <container-dialog id="CancelDialog" button-text="Cancel Shipment" condition="!(shipment.statusId in ['ShipDelivered', 'ShipRejected', 'ShipCancelled'])">


### PR DESCRIPTION
There are two sections with the same name "ShipShippedSection":
one with statusId = "ShipShipped"
and one with statusId = "ShipDelivered".

The section name with statusId = "ShipDelivered" should be "ShipDeliveredSection".
The two section must have different names.

High priority issue because this fails the shipment workflow.