### PR TITLE
Add OrderProposed & OrderRequested to default status filter in FindOrder

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -44,6 +44,7 @@ Written in 2017 by Zhang Wei - zhangwei1979
 Written in 2018 by Daniel Taylor - danieltaylor-nz
 Written in 2018 by Hans Bakker - hansbak
 Written in 2018 by Nirendra Singh - nirendra10695
+Written in 2019 by Jacob Barnes - Tellan
 
 ===========================================================================
 
@@ -75,4 +76,4 @@ Written in 2017 by Zhang Wei - zhangwei1979
 Written in 2018 by Daniel Taylor - danieltaylor-nz
 Written in 2018 by Hans Bakker - hansbak
 Written in 2018 by Nirendra Singh - nirendra10695
-
+Written in 2019 by Jacob Barnes - Tellan

--- a/screen/SimpleScreens/Order/FindOrder.xml
+++ b/screen/SimpleScreens/Order/FindOrder.xml
@@ -183,7 +183,7 @@ along with this software (see the LICENSE.md file). If not, see
                 <search-form-inputs default-order-by="-entryDate,orderId,orderPartSeqId"
                         skip-fields="vendorRoleTypeId,customerRoleTypeId,customerClassificationId,itemTypeEnumId">
                     <!-- NOTE: OrderOpen no longer included by default to exclude shopping cart orders (salesChannelEnumId == 'ScWeb') -->
-                    <default-parameters partStatusId="OrderPlaced,OrderApproved,OrderHold" partStatusId_op="in"
+                    <default-parameters partStatusId="OrderProposed,OrderRequested,OrderPlaced,OrderApproved,OrderHold" partStatusId_op="in"
                             entryDate_poffset="-3" entryDate_period="30d"/></search-form-inputs>
                 <date-filter from-field-name="customerClassFromDate" thru-field-name="customerClassThruDate" ignore="!customerClassificationId"/>
                 <econdition field-name="vendorRoleTypeId" value="OrgInternal" ignore="!'sales'.equalsIgnoreCase(orderType)"/>


### PR DESCRIPTION
We've been using the new Order statuses but find it annoying that they don't appear on the FindOrder list by default. We think that most people could benefit from this.