### PR TITLE
Encoding the workEffort name

### DIFF
--- a/template/shipment/ShipmentLoadPick.xsl-fo.ftl
+++ b/template/shipment/ShipmentLoadPick.xsl-fo.ftl
@@ -70,7 +70,7 @@ along with this software (see the LICENSE.md file). If not, see
                 <fo:table-body><fo:table-row>
                     <fo:table-cell padding="3pt" width="3in">
                         <fo:block font-weight="bold">Picklist</fo:block>
-                        <fo:block>${workEffortId}: <@encodeText workEffort.workEffortName!""/> </fo:block>
+                        <fo:block>${workEffortId}: <@encodeText workEffort.workEffortName!""/></fo:block>
                         <#if warehouseFacility?has_content>
                             <fo:block font-weight="bold">Warehouse</fo:block>
                             <fo:block>${ec.resource.expand("FacilityNameTemplate", "", warehouseFacility)}</fo:block>

--- a/template/shipment/ShipmentLoadPick.xsl-fo.ftl
+++ b/template/shipment/ShipmentLoadPick.xsl-fo.ftl
@@ -70,7 +70,7 @@ along with this software (see the LICENSE.md file). If not, see
                 <fo:table-body><fo:table-row>
                     <fo:table-cell padding="3pt" width="3in">
                         <fo:block font-weight="bold">Picklist</fo:block>
-                        <fo:block>${workEffortId}: ${workEffort.workEffortName}</fo:block>
+                        <fo:block>${workEffortId}: <@encodeText workEffort.workEffortName!""/> </fo:block>
                         <#if warehouseFacility?has_content>
                             <fo:block font-weight="bold">Warehouse</fo:block>
                             <fo:block>${ec.resource.expand("FacilityNameTemplate", "", warehouseFacility)}</fo:block>


### PR DESCRIPTION
A user can enter illegal characters in the workeffort name and this will cause a transformation error