### PR TITLE
Streamlined creation and adding of categories when setting up a store.

### DIFF
--- a/screen/SimpleScreens/ProductStore/FindProductStoreCategory.xml
+++ b/screen/SimpleScreens/ProductStore/FindProductStoreCategory.xml
@@ -20,6 +20,15 @@ along with this software (see the LICENSE.md file). If not, see
 
     <transition name="createStoreCategory"><service-call name="create#mantle.product.store.ProductStoreCategory"/>
         <default-response url="."/></transition>
+
+    <transition name="createCategoryAddStore">
+        <actions>
+            <service-call name="create#mantle.product.category.ProductCategory" in-map="context" out-map="context"/>
+            <service-call name="create#mantle.product.store.ProductStoreCategory" in-map="context"/>
+        </actions>
+        <default-response url="."/>
+    </transition>
+
     <transition name="updateStoreCategory"><service-call name="update#mantle.product.store.ProductStoreCategory"/>
         <default-response url="."/></transition>
     <transition name="deleteStoreCategory"><service-call name="delete#mantle.product.store.ProductStoreCategory"/>
@@ -28,11 +37,44 @@ along with this software (see the LICENSE.md file). If not, see
     <transition-include name="getCategoryList" location="component://SimpleScreens/template/product/ProductTransitions.xml"/>
 
     <widgets>
-        <container-dialog id="NewStoreCategoryDialog" button-text="Add Store Category">
-            <form-single name="NewStoreCategoryForm" transition="createStoreCategory">
+        <container-dialog id="AddStoreCategoryDialog" button-text="Add Store Category">
+            <form-single name="AddStoreCategoryForm" transition="createStoreCategory">
                 <field name="productStoreId"><default-field><hidden/></default-field></field>
                 <field name="productCategoryId"><default-field title="Category"><drop-down>
                     <dynamic-options transition="getCategoryList" server-search="true" min-length="0"/></drop-down></default-field></field>
+                <field name="storeCategoryTypeEnumId"><default-field title="Store Category Type">
+                    <drop-down><entity-options key="${enumId}" text="${description ?: ''}">
+                        <entity-find entity-name="moqui.basic.Enumeration">
+                            <econdition field-name="enumTypeId" value="ProductStoreCategoryType"/>
+                            <order-by field-name="description"/>
+                        </entity-find>
+                    </entity-options></drop-down>
+                </default-field></field>
+                <field name="fromDate"><default-field><date-time type="date-time"/></default-field></field>
+                <field name="submitButton"><default-field title="Create"><submit/></default-field></field>
+            </form-single>
+        </container-dialog>
+
+        <container-dialog id="CreateCategoryDialog" button-text="Create Store Category">
+            <form-single name="CreateCategoryForm" transition="createCategoryAddStore">
+                <field name="productStoreId"><default-field><hidden/></default-field></field>
+                <field name="categoryName"><default-field><text-line/></default-field></field>
+                <field name="productCategoryTypeEnumId"><default-field title="Category Type">
+                    <widget-template-include location="component://webroot/template/screen/BasicWidgetTemplates.xml#enumDropDown">
+                        <set field="enumTypeId" value="ProductCategoryType"/></widget-template-include>
+                </default-field></field>
+                <field name="ownerPartyId"><default-field title="Owner Party">
+                    <drop-down>
+                        <option key="_NA_" text="N/A"/>
+                        <entity-options key="${partyId}" text="PartyNameTemplate">
+                            <entity-find entity-name="mantle.party.PartyDetailAndRole">
+                                <econdition field-name="partyId" from="activeOrgId" ignore="!activeOrgId"/>
+                                <econdition field-name="roleTypeId" value="OrgInternal"/>
+                                <econdition field-name="disabled" value="N" or-null="true"/>
+                                <order-by field-name="organizationName"/></entity-find>
+                        </entity-options>
+                    </drop-down>
+                </default-field></field>
                 <field name="storeCategoryTypeEnumId"><default-field title="Store Category Type">
                     <drop-down><entity-options key="${enumId}" text="${description ?: ''}">
                         <entity-find entity-name="moqui.basic.Enumeration">


### PR DESCRIPTION
Currently you have to go to vapps/PopcAdmin/Catalog/Category to create the category and then go to the store settings and search for it again to add it as a store category.

Here we can do that in one movement. 