### PR TITLE
Revert "Use PostalShippingOrigin instead of PostalShippingDest for Origin Address dropdown"

### DIFF
--- a/screen/MyAccount/Expense/EditExpenseInvoiceItems.xml
+++ b/screen/MyAccount/Expense/EditExpenseInvoiceItems.xml
@@ -95,7 +95,7 @@ along with this software (see the LICENSE.md file). If not, see
                 <conditional-field condition="invoice.statusId == 'InvoiceIncoming'"><text-line size="8"/></conditional-field>
                 <default-field><display currency-unit-field="invoice.currencyUomId"/></default-field>
             </field>
-            <field name="total" from="((quantity?:0.0) * (amount?:0.0))"><default-field><display currency-unit-field="invoice.currencyUomId"/></default-field></field>
+            <field name="total" from="(quantity * amount)"><default-field><display currency-unit-field="invoice.currencyUomId"/></default-field></field>
 
             <field name="delete">
                 <conditional-field condition="invoice.statusId == 'InvoiceIncoming'">

--- a/screen/SimpleScreens/Accounting/OrgSettings/AssetTypes.xml
+++ b/screen/SimpleScreens/Accounting/OrgSettings/AssetTypes.xml
@@ -34,7 +34,7 @@ along with this software (see the LICENSE.md file). If not, see
             <econdition field-name="organizationPartyId"/><order-by field-name="assetTypeDescription,assetClassDescription"/></entity-find>
     </actions>
     <widgets>
-        <container-dialog id="AddConfigDialog" button-text="Add Asset Type Mapping">
+        <container-dialog id="AddConfigDialog" button-text="Add Invoice Type Mapping">
             <form-single name="AddConfigForm" transition="storeConfig">
                 <field name="partyId"><default-field><hidden/></default-field></field>
                 <field name="organizationPartyId"><default-field><hidden/></default-field></field>

--- a/screen/SimpleScreens/Shipment/ShipmentDetail.xml
+++ b/screen/SimpleScreens/Shipment/ShipmentDetail.xml
@@ -204,12 +204,9 @@ along with this software (see the LICENSE.md file). If not, see
             </if>
         </if>
         <if condition="isIncoming &amp;&amp; fromPartyId">
-            <service-call name="mantle.party.ContactServices.get#PartyContactInfoList" out-map="fromPartyShippingDestInfo"
+            <service-call name="mantle.party.ContactServices.get#PartyContactInfoList" out-map="fromPartyShippingInfo"
                     in-map="[partyId:fromPartyId, postalContactMechPurposeId:'PostalShippingDest']"/>
-            <service-call name="mantle.party.ContactServices.get#PartyContactInfoList" out-map="fromPartyShippingOriginInfo"
-                          in-map="[partyId:fromPartyId, postalContactMechPurposeId:'PostalShippingOrigin']"/>
-
-            <set field="shippingPostalAddressList" from="(fromPartyShippingDestInfo.postalAddressList ?: []) + (fromPartyShippingOriginInfo.postalAddressList ?: [])"/>
+            <set field="shippingPostalAddressList" from="fromPartyShippingInfo.postalAddressList ?: []"/>
 
             <if condition="firstRouteSegment.originPostalContactMechId">
                 <service-call name="mantle.party.ContactServices.get#PartyContactInfo" out-map="curOriginPaInfo"


### PR DESCRIPTION
Reverts moqui/SimpleScreens#117 - reverted because of messy commit history and possible missing signature in AUTHORS