### PR TITLE
Squash commit for Add Second Factor Authentication to Moqui project

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ that are otherwise encumbered.
 Signed by git commit adding my legal name and git username:
 
 Written in 2016-2020 by David E. Jones - jonesde
+Written in 2021-2021 by D. Michael Jones - acetousk
 Written in 2016-2016 by Sam Hamilton - samhamilton
 Written in 2016-2018 by Jens Hardings - jenshp
 Written in 2016-2016 by Michal Rovnanik - mrovnanik
@@ -69,6 +70,7 @@ litigation is filed.
 Signed by git commit adding my legal name and git username:
 
 Written in 2016-2020 by David E. Jones - jonesde
+Written in 2021-2021 by D. Michael Jones - acetousk
 Written in 2016-2016 by Sam Hamilton - samhamilton
 Written in 2016-2017 by Jens Hardings - jenshp
 Written in 2016-2016 by Michal Rovnanik - mrovnanik

--- a/screen/MyAccount/User/Account.xml
+++ b/screen/MyAccount/User/Account.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-This software is in the public domain under CC0 1.0 Universal plus a 
+This software is in the public domain under CC0 1.0 Universal plus a
 Grant of Patent License.
 
 To the extent possible under law, the author(s) have dedicated all
@@ -26,8 +26,35 @@ along with this software (see the LICENSE.md file). If not, see
     <transition name="changePassword"><service-call name="org.moqui.impl.UserServices.update#Password"/>
         <default-response url="."/><error-response url="."/></transition>
 
+    <transition name="createUserAuthcFactorTotp"><service-call name="org.moqui.impl.UserServices.create#UserAuthcFactorTotp"/>
+        <default-response url="."/></transition>
+    <transition name="verifyUserAuthcFactorTotp"><service-call name="org.moqui.impl.UserServices.verify#UserAuthcFactorTotp"/>
+        <default-response url="."/></transition>
+    <transition name="createUserAuthcFactorSingleUse">
+        <service-call name="org.moqui.impl.UserServices.create#SingleUseAuthcCodes"/>
+        <actions><script>ec.web.sessionAttributes.put("singleUseCodes", singleUseCodes)</script></actions>
+        <default-response url="."/></transition>
+    <transition name="createUserAuthcFactorEmail"><service-call name="org.moqui.impl.UserServices.create#EmailUserAuthcFactor"/>
+        <default-response url="."/></transition>
+    <transition name="factorSubmit"><service-call name="org.moqui.impl.UserServices.invalidate#UserAuthcFactorEntry" in-map="context"/>
+        <default-response url="."/></transition>
+
+    <subscreens>
+        <subscreens-item name="VerifyEmail" location="component://tools/screen/System/Security/UserAccount/UserAccountDetail/VerifyEmail.xml"/>
+        <subscreens-item name="VerifyTotp" location="component://tools/screen/System/Security/UserAccount/UserAccountDetail/VerifyTotp.xml"/>
+    </subscreens>
+
     <actions>
         <entity-find-one entity-name="mantle.party.PersonAndUserAccount" value-field="personAndUserAccount"/>
+
+        <set field="singleUseCodes" from="ec.web.sessionAttributes.remove('singleUseCodes')"/>
+
+        <entity-find entity-name="moqui.security.UserAuthcFactor" list="userAuthcFactorList">
+            <date-filter/>
+            <econdition field-name="userId"/>
+        </entity-find>
+
+
         <if condition="personAndUserAccount == null"><set field="personAndUserAccount" from="ec.user.userAccount"/></if>
 
         <if condition="partyId &amp;&amp; !personAndUserAccount?.emailAddress">
@@ -69,6 +96,88 @@ along with this software (see the LICENSE.md file). If not, see
 
                     <field name="submitButton"><default-field title="Update"><submit/></default-field></field>
                 </form-single>
+                <section name="SingleUseCodesDisplay" condition="singleUseCodes">
+                    <actions>
+                        <set field="singleUseCodes1" from="[]"/><set field="singleUseCodes2" from="[]"/><set field="singleUseCodes3" from="[]"/>
+                        <script>
+                            int i;
+                            for(code in singleUseCodes){
+                            if( i%3 == 0 ) { singleUseCodes1.add(singleUseCodes[i]);}
+                            else if(i%3==1){ singleUseCodes2.add(singleUseCodes[i]);}
+                            else if(i%3==2){ singleUseCodes3.add(singleUseCodes[i]);}
+                            i++; }</script>
+                    </actions>
+                    <widgets>
+                        <container-box>
+                            <box-header><label text="Single Use Codes" style="text-danger" type="h5"/></box-header>
+                            <box-body>
+                                <label text="Write down these codes. They will only appear once." style="text-danger"/>
+                                <container-row>
+                                    <row-col lg="4">
+                                        <container type="ul">
+                                            <section-iterate name="SingleUseCodes1" list="singleUseCodes1" entry="code1">
+                                                <widgets><container type="li"><label text="${code1}" style="text-danger"/></container></widgets></section-iterate>
+                                        </container></row-col>
+                                    <row-col lg="4">
+                                        <container type="ul">
+                                            <section-iterate name="SingleUseCodes2" list="singleUseCodes2" entry="code2">
+                                                <widgets><container type="li"><label text="${code2}" style="text-danger"/></container></widgets>
+                                            </section-iterate></container></row-col>
+                                    <row-col lg="4">
+                                        <container type="ul">
+                                            <section-iterate name="SingleUseCodes3" list="singleUseCodes3" entry="code3">
+                                                <widgets><container type="li"><label text="${code3}" style="text-danger"/></container></widgets>
+                                            </section-iterate></container></row-col>
+                                </container-row>
+                            </box-body></container-box>
+                    </widgets>
+                </section>
+                <container-box><box-header title="Authentication Methods"/>
+                    <box-toolbar>
+                        <container-dialog id="CreateTotpDialog" button-text="Add Authenticator App">
+                            <form-single name="CreateUserAuthcFactorTotp" transition="createUserAuthcFactorTotp">
+                                <field name="userId" from="userId"><default-field><hidden/></default-field></field>
+                                <field name="thruDate" from="ec.user.nowTimestamp + 365"><default-field><date-time/></default-field></field>
+                                <field name="submitButton"><default-field title="Add"><submit/></default-field></field>
+                            </form-single></container-dialog>
+                        <container-dialog id="AddSingleUseDialog" button-text="Add Single Use Codes">
+                            <form-single name="CreateUserAuthcFactorSingleUse" transition="createUserAuthcFactorSingleUse">
+                                <field name="userId" from="userId"><default-field><hidden/></default-field></field>
+                                <field name="fromDate" from="ec.user.nowTimestamp + 365"><default-field><date-time/></default-field></field>
+                                <field name="numberOfCodes"><default-field title="Number of Codes"><text-line size="30" input-type="Integer" default-value="6"/></default-field></field>
+                                <field name="submitButton"><default-field title="Add" ><submit/></default-field></field>
+                            </form-single></container-dialog>
+                        <container-dialog id="AddEmailFactor" button-text="Add Email Factor">
+                            <form-single name="CreateUserAuthcFactorEmail" transition="createUserAuthcFactorEmail">
+                                <field name="userId" from="userId"><default-field><hidden/></default-field></field>
+                                <field name="thruDate" from="ec.user.nowTimestamp + 365"><default-field><date-time/></default-field></field>
+                                <field name="factorOption" from="ec.user.userAccount.emailAddress"><default-field title="Email"><text-line size="30"/></default-field></field>
+                                <field name="submitButton"><default-field title="Add"><submit/></default-field></field>
+                            </form-single>
+                        </container-dialog>
+
+                    </box-toolbar><box-body-nopad>
+                        <form-list name="UserAuthcFactorList" list="userAuthcFactorList" transition="factorSubmit">
+                            <field name="factorId"><default-field><display/></default-field></field>
+                            <field name="userId" from="userId"><default-field><hidden/></default-field></field>
+                            <field name="fromFactorId"><header-field/><default-field><display/></default-field></field>
+                            <field name="factorTypeEnumId"><header-field title="Factor Type"/><default-field><display-entity entity-name="moqui.basic.Enumeration" text="${description}"/></default-field></field>
+                            <field name="fromDate"><default-field><display/></default-field></field>
+                            <field name="thruDate"><default-field><display/></default-field></field>
+                            <field name="action">
+                                <conditional-field condition="needsValidation == 'Y' &amp;&amp; factorTypeEnumId == 'UafTotp'">
+                                    <dynamic-dialog id="VerifyTotpDialog" button-text="Verify" transition="VerifyTotp" parameter-map="[userId:userId, factorId:factorId, verify:true]"/></conditional-field>
+                                <conditional-field condition="needsValidation == 'Y' &amp;&amp; factorTypeEnumId == 'UafEmail'">
+                                    <dynamic-dialog id="VerifyEmailDialog" button-text="Verify" transition="VerifyEmail" parameter-map="[userId:userId, factorId:factorId, userEmail:factorOption]"/></conditional-field>
+                                <conditional-field condition="needsValidation == 'N' &amp;&amp; factorTypeEnumId == 'UafEmail'">
+                                    <label text="${factorOption}"/></conditional-field>
+                            </field>
+                            <field name="needsValidation"><default-field><display/></default-field></field>
+                            <field name="delete"><default-field title=" "><submit text=" " icon="fa fa-trash"/></default-field></field>
+                        </form-list>
+                    </box-body-nopad>
+                </container-box>
+
             </panel-center>
         </container-panel>
     </widgets>


### PR DESCRIPTION
The pull request makes changes to moqui-framework, moqui-runtime, and SimpleScreens.

The biggest things to check are:

    In my development environment, I was occasionally getting 28 second loading screens when calling services in UserServices.xml to create a UserAuthcFactor. Make sure that in other environments this doesn't happen.
    Ensure that the forms don't allow the user to specify their userId so that permissions for users are enforced.

In SimpleScreens:

    Add a authentication configuration method to Account.xml including features:
        Add any type of authentication method for any user
        Verify authentication types like authenticator app (totp) and email (NOTE: It currently does not matter if a user's authentication type is verified before it is used. In the future this probably will become necessary)
        Invalidate any type of authentication method for any user
