### PR TITLE
Add Screen Sections for ProductOtherIdentification, ProductCategoryIdent, and ProductStoreDataDocument

### DIFF
--- a/screen/SimpleScreens/Catalog/Category/EditCategory.xml
+++ b/screen/SimpleScreens/Catalog/Category/EditCategory.xml
@@ -32,7 +32,7 @@ along with this software (see the LICENSE.md file). If not, see
         <default-response url="."/></transition>
     <transition name="deleteProductCategoryIdent"><service-call name="delete#mantle.product.category.ProductCategoryIdent"/>
         <default-response url="."/></transition>
-    <transition name="generateProductCategoryIdent">
+    <transition name="generateUrlSlugCategoryIdent">
         <service-call name="mantle.product.StoreServices.generate#UrlSlugFromCategoryName"/>
         <default-response url="."/></transition>
 
@@ -127,18 +127,18 @@ along with this software (see the LICENSE.md file). If not, see
                     </form-list>
                 </box-body-nopad></container-box>
                 <container-box><box-header title="Category Identification"/><box-toolbar>
-                    <form-single name="GenerateCategoryIdent" transition="generateProductCategoryIdent">
+                    <form-single name="GenerateCategoryIdent" transition="generateUrlSlugCategoryIdent">
                         <field name="productCategoryId"><default-field><hidden/></default-field></field>
                         <field name="categoryName" from="category?.categoryName"><default-field><hidden/></default-field></field>
                         <field name="submitButton"><conditional-field title="Generate Url Slug" tooltip="Generate Url Slug from the Category's Name"
-                                                                      condition="pciList?.findAll{it.productCategoryIdentTypeEnumId == 'PcitSlug' }?.size() == 0">
+                                                                      condition="pciList?.findAll{it.identTypeEnumId == 'PcitUrlSlug' }?.size() == 0">
                             <submit/></conditional-field></field></form-single>
                     <container-dialog id="AddCategoryIdentDialog" button-text="New Category Identification">
                         <form-single name="AddCategoryIdentForm" transition="createProductCategoryIdent">
                             <field name="productCategoryId"><default-field><hidden/></default-field></field>
                             <field name="productCategoryIdentId"><default-field tooltip="Id of Product Category to Product Category Ident Relationship">
                                 <text/></default-field></field>
-                            <field name="productCategoryIdentTypeEnumId"><default-field title="Identity Type">
+                            <field name="identTypeEnumId"><default-field title="Identity Type">
                                 <drop-down><list-options list="productCategoryIdentTypeList" key="${enumId}" text="${description}"/></drop-down>
                             </default-field></field>
                             <field name="productStoreId"><default-field title="Product Store">
@@ -155,7 +155,7 @@ along with this software (see the LICENSE.md file). If not, see
                     <form-list name="CategoryIdentForm" list="pciList" transition="updateProductCategoryIdent">
                         <field name="productCategoryIdentId"><default-field><hidden/></default-field></field>
                         <field name="productCategoryId"><default-field><hidden/></default-field></field>
-                        <field name="productCategoryIdentTypeEnumId"><default-field title="Identity Type"><drop-down size="4">
+                        <field name="identTypeEnumId"><default-field title="Identity Type"><drop-down size="4">
                             <list-options list="productCategoryIdentTypeList" key="${enumId}" text="${description}"/>
                         </drop-down></default-field></field>
                         <field name="productStoreId"><default-field title="Product Store"><drop-down size="4" allow-empty="true">

--- a/screen/SimpleScreens/Catalog/Category/EditCategory.xml
+++ b/screen/SimpleScreens/Catalog/Category/EditCategory.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-This software is in the public domain under CC0 1.0 Universal plus a 
+This software is in the public domain under CC0 1.0 Universal plus a
 Grant of Patent License.
 
 To the extent possible under law, the author(s) have dedicated all
@@ -26,6 +26,16 @@ along with this software (see the LICENSE.md file). If not, see
     <transition name="updateProductCategoryFeatGrpAppl"><service-call name="update#mantle.product.feature.ProductCategoryFeatGrpAppl"/>
         <default-response url="."/></transition>
 
+    <transition name="createProductCategoryIdent"><service-call name="create#mantle.product.category.ProductCategoryIdent"/>
+        <default-response url="."/></transition>
+    <transition name="updateProductCategoryIdent"><service-call name="update#mantle.product.category.ProductCategoryIdent"/>
+        <default-response url="."/></transition>
+    <transition name="deleteProductCategoryIdent"><service-call name="delete#mantle.product.category.ProductCategoryIdent"/>
+        <default-response url="."/></transition>
+    <transition name="generateProductCategoryIdent">
+        <service-call name="mantle.product.StoreServices.generate#UrlSlugFromCategoryName"/>
+        <default-response url="."/></transition>
+
     <transition name="createProductCategoryRollup"><service-call name="create#mantle.product.category.ProductCategoryRollup"
             in-map="context + [productCategoryId:childProductCategoryId]"/><default-response url="."/></transition>
     <transition name="updateProductCategoryRollup"><service-call name="update#mantle.product.category.ProductCategoryRollup"
@@ -39,6 +49,15 @@ along with this software (see the LICENSE.md file). If not, see
         <entity-find-one entity-name="mantle.product.category.ProductCategory" value-field="category" cache="false"/>
         <if condition="category == null"><return error="true" message="Category not found with ID ${productCategoryId}"/></if>
         <set field="curProductCategoryId" from="productCategoryId"/>
+
+        <entity-find entity-name="moqui.basic.Enumeration" limit="200" cache="true" list="productCategoryIdentTypeList">
+            <econdition field-name="enumTypeId" value="ProductCategoryIdentType"/><order-by field-name="description"/></entity-find>
+        <entity-find entity-name="mantle.product.store.ProductStore" limit="200" cache="true" list="productStoreList">
+            <order-by field-name="storeName"/></entity-find>
+        <entity-find entity-name="mantle.marketing.segment.MarketSegment" limit="200" cache="true" list="marketSegmentList">
+            <order-by field-name="description"/></entity-find>
+        <entity-find entity-name="mantle.product.category.ProductCategoryIdent" list="pciList">
+            <econdition field-name="productCategoryId"/></entity-find>
     </actions>
     <widgets>
         <container-row><row-col md="7">
@@ -107,6 +126,50 @@ along with this software (see the LICENSE.md file). If not, see
                         </default-field></field>
                     </form-list>
                 </box-body-nopad></container-box>
+                <container-box><box-header title="Category Identification"/><box-toolbar>
+                    <form-single name="GenerateCategoryIdent" transition="generateProductCategoryIdent">
+                        <field name="productCategoryId"><default-field><hidden/></default-field></field>
+                        <field name="categoryName" from="category?.categoryName"><default-field><hidden/></default-field></field>
+                        <field name="submitButton"><conditional-field title="Generate Url Slug" tooltip="Generate Url Slug from the Category's Name"
+                                                                      condition="pciList?.findAll{it.productCategoryIdentTypeEnumId == 'PcitSlug' }?.size() == 0">
+                            <submit/></conditional-field></field></form-single>
+                    <container-dialog id="AddCategoryIdentDialog" button-text="New Category Identification">
+                        <form-single name="AddCategoryIdentForm" transition="createProductCategoryIdent">
+                            <field name="productCategoryId"><default-field><hidden/></default-field></field>
+                            <field name="productCategoryIdentId"><default-field tooltip="Id of Product Category to Product Category Ident Relationship">
+                                <text/></default-field></field>
+                            <field name="productCategoryIdentTypeEnumId"><default-field title="Identity Type">
+                                <drop-down><list-options list="productCategoryIdentTypeList" key="${enumId}" text="${description}"/></drop-down>
+                            </default-field></field>
+                            <field name="productStoreId"><default-field title="Product Store">
+                                <drop-down allow-empty="true"><list-options list="productStoreList" key="${productStoreId}" text="${storeName}"/></drop-down>
+                            </default-field></field>
+                            <field name="marketSegmentId"><default-field>
+                                <drop-down allow-empty="true"><list-options list="marketSegmentList" key="${marketSegmentId}" text="${description}"/></drop-down>
+                            </default-field></field>
+                            <field name="idValue"><default-field><text-line size="20"/></default-field></field>
+                            <field name="submitButton"><default-field title="Apply"><submit/></default-field></field>
+                        </form-single>
+                    </container-dialog>
+                </box-toolbar><box-body>
+                    <form-list name="CategoryIdentForm" list="pciList" transition="updateProductCategoryIdent">
+                        <field name="productCategoryIdentId"><default-field><hidden/></default-field></field>
+                        <field name="productCategoryId"><default-field><hidden/></default-field></field>
+                        <field name="productCategoryIdentTypeEnumId"><default-field title="Identity Type"><drop-down size="4">
+                            <list-options list="productCategoryIdentTypeList" key="${enumId}" text="${description}"/>
+                        </drop-down></default-field></field>
+                        <field name="productStoreId"><default-field title="Product Store"><drop-down size="4" allow-empty="true">
+                            <list-options list="productStoreList" key="${productStoreId}" text="${storeName}"/>
+                        </drop-down></default-field></field>
+                        <field name="marketSegmentId"><default-field title="Market Segment"><drop-down size="4" allow-empty="true">
+                            <list-options list="marketSegmentList" key="${marketSegmentId}" text="${description}"/>
+                        </drop-down></default-field></field>
+                        <field name="idValue"><default-field><text-line size="20"/></default-field></field>
+                        <field name="submitButton"><default-field title="Update"><submit/></default-field></field>
+                        <field name="delete"><default-field title=""><link url="deleteProductCategoryIdent" text=""
+                            icon="fa fa-trash" confirmation="Delete Product Category Identity Record?"/></default-field></field>
+                    </form-list>
+                </box-body></container-box>
             </widgets></section>
         </row-col><row-col md="5">
             <container-box><box-header title="Parent Categories"/><box-body-nopad>

--- a/screen/SimpleScreens/Catalog/Product/EditProduct.xml
+++ b/screen/SimpleScreens/Catalog/Product/EditProduct.xml
@@ -33,6 +33,17 @@ along with this software (see the LICENSE.md file). If not, see
         <parameter name="productIdTypeEnumId"/>
         <service-call name="delete#mantle.product.ProductIdentification"/><default-response url="."/></transition>
 
+    <transition name="createProductOtherIdentification">
+        <service-call name="create#mantle.product.ProductOtherIdentification"/><default-response url="."/></transition>
+    <transition name="updateProductOtherIdentification">
+        <service-call name="update#mantle.product.ProductOtherIdentification"/><default-response url="."/></transition>
+    <transition name="deleteProductOtherIdentification">
+        <parameter name="productIdTypeEnumId"/>
+        <service-call name="delete#mantle.product.ProductOtherIdentification"/><default-response url="."/></transition>
+    <transition name="generateProductOtherIdentification">
+        <service-call name="mantle.product.StoreServices.generate#UrlSlugFromProductName"/>
+        <default-response url="."/></transition>
+
     <transition name="createProductFeature"><service-call name="mantle.product.ProductServices.create#ProductFeature"/>
         <default-response url="."/></transition>
     <transition name="applyProductFeatures"><service-call name="mantle.product.ProductServices.apply#ProductFeatures"/>
@@ -84,9 +95,21 @@ along with this software (see the LICENSE.md file). If not, see
         <entity-find-one entity-name="mantle.product.Product" value-field="product" cache="false"/>
         <if condition="product == null"><return error="true" message="Product not found with ID ${productId}"/></if>
 
+        <entity-find entity-name="moqui.basic.Enumeration" limit="200" cache="true" list="productIdentificationTypeList">
+            <econdition field-name="enumTypeId" value="ProductIdentificationType"/>
+            <econdition field-name="enumId" operator="not-in" from="productIdTypeEnumIds" ignore-if-empty="true"/>
+            <order-by field-name="description"/></entity-find>
         <entity-find entity-name="mantle.product.ProductIdentification" list="productIdentificationList">
             <econdition field-name="productId"/></entity-find>
         <set field="productIdTypeEnumIds" from="productIdentificationList*.productIdTypeEnumId"/>
+
+        <entity-find entity-name="mantle.product.store.ProductStore" limit="200" cache="true" list="productStoreList">
+            <order-by field-name="storeName"/></entity-find>
+        <entity-find entity-name="mantle.marketing.segment.MarketSegment" limit="200" cache="true" list="marketSegmentList">
+            <order-by field-name="description"/></entity-find>
+        <entity-find entity-name="mantle.product.ProductOtherIdentification" list="productOtherIdentificationList">
+            <econdition field-name="productId"/></entity-find>
+        <set field="productIdOtherTypeEnumIds" from="productOtherIdentificationList*.productIdTypeEnumId"/>
 
         <set field="isEquipment" from="product.assetTypeEnumId in ['AstTpEquipment', 'AstTpRental']"/>
         <set field="isInventory" from="product.assetTypeEnumId == 'AstTpInventory'"/>
@@ -221,13 +244,7 @@ along with this software (see the LICENSE.md file). If not, see
                     <form-single name="AddIdentificationForm" transition="createProductIdentification">
                         <field name="productId"><default-field><hidden/></default-field></field>
                         <field name="productIdTypeEnumId"><default-field title="ID Type">
-                            <drop-down><entity-options key="${enumId}" text="${description}">
-                                <entity-find entity-name="moqui.basic.Enumeration">
-                                    <econdition field-name="enumTypeId" value="ProductIdentificationType"/>
-                                    <econdition field-name="enumId" operator="not-in" from="productIdTypeEnumIds" ignore-if-empty="true"/>
-                                    <order-by field-name="description"/>
-                                </entity-find>
-                            </entity-options></drop-down>
+                            <drop-down><list-options list="productIdentificationTypeList.findAll{!productIdTypeEnumIds.contains(it.enumId)}" key="${enumId}" text="${description}"/></drop-down>
                         </default-field></field>
                         <field name="idValue"><default-field><text-line size="20"/></default-field></field>
                         <field name="submitButton"><default-field title="Add"><submit/></default-field></field>
@@ -242,6 +259,47 @@ along with this software (see the LICENSE.md file). If not, see
                     <field name="submitButton"><default-field title="Update"><submit/></default-field></field>
                     <field name="removeButton"><default-field title=""><link url="deleteProductIdentification"
                             icon="fa fa-trash" confirmation="Delete this ID?"/></default-field></field>
+                </form-list>
+            </box-body></container-box>
+
+            <container-box><box-header title="Other Identification"/><box-toolbar>
+                <form-single name="GenerateOtherIdentification" transition="generateProductOtherIdentification">
+                    <field name="productId"><default-field><hidden/></default-field></field>
+                    <field name="productName" from="product?.productName"><default-field><hidden/></default-field></field>
+                    <field name="submitButton"><conditional-field title="Generate Url Slug" tooltip="Generate Url Slug from the Product's Name"
+                        condition="productOtherIdentificationList?.findAll{it.productIdTypeEnumId == 'PidtSlug' }?.size() == 0">
+                        <submit/></conditional-field></field></form-single>
+                <container-dialog id="AddOtherIdentificationDialog" button-text="Add Other Identification">
+                    <form-single name="AddOtherIdentificationForm" transition="createProductOtherIdentification">
+                        <field name="productId"><default-field><hidden/></default-field></field>
+                        <field name="productIdTypeEnumId"><default-field title="ID Type">
+                            <drop-down><list-options list="productIdentificationTypeList" key="${enumId}" text="${description}"/></drop-down>
+                        </default-field></field>
+                        <field name="productStoreId"><default-field>
+                            <drop-down allow-empty="true"><list-options list="productStoreList" key="${productStoreId}" text="${storeName}"/></drop-down>
+                        </default-field></field>
+                        <field name="marketSegmentId"><default-field>
+                            <drop-down allow-empty="true"><list-options list="marketSegmentList" key="${marketSegmentId}" text="${description}"/></drop-down>
+                        </default-field></field>
+                        <field name="idValue"><default-field><text-line size="20"/></default-field></field>
+                        <field name="submitButton"><default-field title="Add"><submit/></default-field></field>
+                    </form-single>
+                </container-dialog>
+            </box-toolbar><box-body>
+                <form-list name="OtherIdentificationsForm" list="productOtherIdentificationList" transition="updateProductOtherIdentification">
+                    <field name="productId"><default-field><hidden/></default-field></field>
+                    <field name="productIdTypeEnumId"><default-field title="ID Type">
+                        <drop-down><list-options list="productIdentificationTypeList" key="${enumId}" text="${description}"/></drop-down></default-field>
+                    </field>
+                    <field name="productStoreId"><default-field>
+                        <drop-down allow-empty="true"><list-options list="productStoreList" key="${productStoreId}" text="${storeName}"/></drop-down>
+                    </default-field></field>
+                    <field name="marketSegmentId"><default-field>
+                        <drop-down allow-empty="true"><list-options list="marketSegmentList" key="${marketSegmentId}" text="${description}"/></drop-down>
+                    </default-field></field>
+                    <field name="idValue"><default-field><text-line size="20"/></default-field></field>
+                    <field name="submitButton"><default-field title="Update"><submit/></default-field></field>
+                    <field name="removeButton"><default-field title=""><link url="deleteProductOtherIdentification" icon="fa fa-trash" confirmation="Delete this ID?"/></default-field></field>
                 </form-list>
             </box-body></container-box>
 

--- a/screen/SimpleScreens/Catalog/Product/EditProduct.xml
+++ b/screen/SimpleScreens/Catalog/Product/EditProduct.xml
@@ -33,14 +33,15 @@ along with this software (see the LICENSE.md file). If not, see
         <parameter name="productIdTypeEnumId"/>
         <service-call name="delete#mantle.product.ProductIdentification"/><default-response url="."/></transition>
 
-    <transition name="createProductOtherIdentification">
-        <service-call name="create#mantle.product.ProductOtherIdentification"/><default-response url="."/></transition>
-    <transition name="updateProductOtherIdentification">
-        <service-call name="update#mantle.product.ProductOtherIdentification"/><default-response url="."/></transition>
+    <transition name="createProductOtherIdentification"><parameter name="idValue" required="true"/>
+        <service-call name="create#mantle.product.ProductOtherIdentification"/>
+        <default-response url="."/></transition>
+    <transition name="updateProductOtherIdentification"><service-call name="update#mantle.product.ProductOtherIdentification"/>
+        <default-response url="."/></transition>
     <transition name="deleteProductOtherIdentification">
         <parameter name="productIdTypeEnumId"/>
         <service-call name="delete#mantle.product.ProductOtherIdentification"/><default-response url="."/></transition>
-    <transition name="generateProductOtherIdentification">
+    <transition name="generateUrlSlugOtherIdent">
         <service-call name="mantle.product.StoreServices.generate#UrlSlugFromProductName"/>
         <default-response url="."/></transition>
 
@@ -263,11 +264,11 @@ along with this software (see the LICENSE.md file). If not, see
             </box-body></container-box>
 
             <container-box><box-header title="Other Identification"/><box-toolbar>
-                <form-single name="GenerateOtherIdentification" transition="generateProductOtherIdentification">
+                <form-single name="GenerateOtherIdentification" transition="generateUrlSlugOtherIdent">
                     <field name="productId"><default-field><hidden/></default-field></field>
                     <field name="productName" from="product?.productName"><default-field><hidden/></default-field></field>
                     <field name="submitButton"><conditional-field title="Generate Url Slug" tooltip="Generate Url Slug from the Product's Name"
-                        condition="productOtherIdentificationList?.findAll{it.productIdTypeEnumId == 'PidtSlug' }?.size() == 0">
+                        condition="productOtherIdentificationList?.findAll{it.productIdTypeEnumId == 'PidtUrlSlug' }?.size() == 0">
                         <submit/></conditional-field></field></form-single>
                 <container-dialog id="AddOtherIdentificationDialog" button-text="Add Other Identification">
                     <form-single name="AddOtherIdentificationForm" transition="createProductOtherIdentification">

--- a/screen/SimpleScreens/ProductStore/EditProductStore.xml
+++ b/screen/SimpleScreens/ProductStore/EditProductStore.xml
@@ -409,8 +409,8 @@ along with this software (see the LICENSE.md file). If not, see
                         <box-toolbar><container-dialog id="NewStoreDataDocumentDialog" button-text="Add Store Data Document">
                             <form-single name="NewStoreDataDocumentForm" transition="createStoreDataDocument">
                                 <field name="productStoreId"><default-field><hidden/></default-field></field>
-                                <field name="storeDocumentTypeEnumId"><default-field title="Store Data Document Type">
-                                    <drop-down><list-options list="storeDataDocumentTypeList.findAll{!storeDataDocumentList.storeDocumentTypeEnumId.contains(it.enumId)}" key="${enumId}" text="${enumId}: ${description ?: ''}"/></drop-down>
+                                <field name="typeEnumId"><default-field title="Store Data Document Type">
+                                    <drop-down><list-options list="storeDataDocumentTypeList.findAll{!storeDataDocumentList.typeEnumId.contains(it.enumId)}" key="${enumId}" text="${enumId}: ${description ?: ''}"/></drop-down>
                                 </default-field></field>
                                 <field name="dataDocumentId"><default-field title="Data Document">
                                     <drop-down><list-options list="dataDocumentList" key="${dataDocumentId}" text="${dataDocumentId} - ${documentName}"/></drop-down>
@@ -421,7 +421,7 @@ along with this software (see the LICENSE.md file). If not, see
                         <box-body>
                             <form-list name="StoreDataDocumentForm" list="storeDataDocumentList" transition="updateStoreDataDocument">
                                 <field name="productStoreId"><default-field><hidden/></default-field></field>
-                                <field name="storeDocumentTypeEnumId"><default-field title="Store Data Document Type"><display-entity
+                                <field name="typeEnumId"><default-field title="Store Data Document Type"><display-entity
                                         entity-name="moqui.basic.Enumeration"/></default-field></field>
                                 <field name="dataDocumentId"><default-field title="Data Document">
                                     <drop-down><list-options list="dataDocumentList" key="${dataDocumentId}" text="${dataDocumentId} - ${documentName}"/></drop-down>

--- a/screen/SimpleScreens/ProductStore/EditProductStore.xml
+++ b/screen/SimpleScreens/ProductStore/EditProductStore.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-This software is in the public domain under CC0 1.0 Universal plus a 
+This software is in the public domain under CC0 1.0 Universal plus a
 Grant of Patent License.
 
 To the extent possible under law, the author(s) have dedicated all
@@ -43,6 +43,13 @@ along with this software (see the LICENSE.md file). If not, see
     <transition name="createPaymentGateway"><service-call name="create#mantle.product.store.ProductStorePaymentGateway"/>
         <default-response url="."/></transition>
     <transition name="deletePaymentGateway"><service-call name="delete#mantle.product.store.ProductStorePaymentGateway"/>
+        <default-response url="."/></transition>
+
+    <transition name="createStoreDataDocument"><service-call name="create#mantle.product.store.ProductStoreDataDocument"/>
+        <default-response url="."/></transition>
+    <transition name="updateStoreDataDocument"><service-call name="update#mantle.product.store.ProductStoreDataDocument"/>
+        <default-response url="."/></transition>
+    <transition name="deleteStoreDataDocument"><service-call name="delete#mantle.product.store.ProductStoreDataDocument"/>
         <default-response url="."/></transition>
 
     <transition-include name="getFacilityList" location="component://SimpleScreens/template/facility/FacilityTransitions.xml"/>
@@ -322,7 +329,7 @@ along with this software (see the LICENSE.md file). If not, see
                                           parameter-map="[productStoreId:productStoreId, carrierPartyId:carrierPartyId]"
                                           confirmation="Are you sure you want to remove this Shipping Gateway?"/>
                                 </default-field></field>
-                                
+
                                 <columns>
                                     <column><field-ref name="carrierPartyId"/><field-ref name="shippingGatewayConfigId"/></column>
                                     <column><field-ref name="billingCountry"/><field-ref name="billingAccount"/></column>
@@ -339,7 +346,7 @@ along with this software (see the LICENSE.md file). If not, see
             <section name="PaymentGatewaysSection">
                 <actions>
                     <entity-find entity-name="mantle.product.store.ProductStorePaymentGateway" list="storePaymentGateway">
-                        <econdition field-name="productStoreId" value="${productStoreId}" />
+                        <econdition field-name="productStoreId"/>
                     </entity-find>
                 </actions>
                 <widgets>
@@ -385,6 +392,51 @@ along with this software (see the LICENSE.md file). If not, see
                     </container-box>
                 </widgets>
             </section>
+
+            <section name="StoreDataDocumentSection">
+                <actions>
+                    <entity-find entity-name="mantle.product.store.ProductStoreDataDocument" limit="200" cache="true" list="storeDataDocumentList">
+                        <econdition field-name="productStoreId"/></entity-find>
+                    <entity-find entity-name="moqui.entity.document.DataDocument" limit="200" cache="true" list="dataDocumentList">
+                        <order-by field-name="documentName"/></entity-find>
+                    <entity-find entity-name="moqui.basic.Enumeration" limit="200" cache="true" list="storeDataDocumentTypeList">
+                        <econdition field-name="enumTypeId" value="ProductStoreDataDocumentType"/>
+                        <order-by field-name="enumId"/></entity-find>
+                </actions>
+                <widgets>
+                    <container-box>
+                        <box-header title="Store Data Documents"/>
+                        <box-toolbar><container-dialog id="NewStoreDataDocumentDialog" button-text="Add Store Data Document">
+                            <form-single name="NewStoreDataDocumentForm" transition="createStoreDataDocument">
+                                <field name="productStoreId"><default-field><hidden/></default-field></field>
+                                <field name="storeDataDocumentTypeEnumId"><default-field title="Store Data Document Type">
+                                    <drop-down><list-options list="storeDataDocumentTypeList.findAll{!storeDataDocumentList.storeDataDocumentTypeEnumId.contains(it.enumId)}" key="${enumId}" text="${enumId}: ${description ?: ''}"/></drop-down>
+                                </default-field></field>
+                                <field name="dataDocumentId"><default-field title="Data Document">
+                                    <drop-down><list-options list="dataDocumentList" key="${dataDocumentId}" text="${dataDocumentId} - ${documentName}"/></drop-down>
+                                </default-field></field>
+                                <field name="submitButton"><default-field title="Create"><submit/></default-field></field>
+                            </form-single>
+                        </container-dialog></box-toolbar>
+                        <box-body>
+                            <form-list name="StoreDataDocumentForm" list="storeDataDocumentList" transition="updateStoreDataDocument">
+                                <field name="productStoreId"><default-field><hidden/></default-field></field>
+                                <field name="storeDataDocumentTypeEnumId"><default-field title="Store Data Document Type"><display-entity
+                                        entity-name="moqui.basic.Enumeration"/></default-field></field>
+                                <field name="dataDocumentId"><default-field title="Data Document">
+                                    <drop-down><list-options list="dataDocumentList" key="${dataDocumentId}" text="${dataDocumentId} - ${documentName}"/></drop-down>
+                                </default-field></field>
+                                <field name="submitButton"><default-field title="Update"><submit/></default-field></field>
+                                <field name="deleteButton" align="right"><default-field title="">
+                                    <link url="deleteStoreDataDocument" icon="fa fa-trash"
+                                          confirmation="Are you sure you want to remove this Store Data Document?"/>
+                                </default-field></field>
+                            </form-list>
+                        </box-body>
+                    </container-box>
+                </widgets>
+            </section>
+
         </row-col></container-row>
     </widgets>
 </screen>

--- a/screen/SimpleScreens/ProductStore/EditProductStore.xml
+++ b/screen/SimpleScreens/ProductStore/EditProductStore.xml
@@ -409,8 +409,8 @@ along with this software (see the LICENSE.md file). If not, see
                         <box-toolbar><container-dialog id="NewStoreDataDocumentDialog" button-text="Add Store Data Document">
                             <form-single name="NewStoreDataDocumentForm" transition="createStoreDataDocument">
                                 <field name="productStoreId"><default-field><hidden/></default-field></field>
-                                <field name="storeDataDocumentTypeEnumId"><default-field title="Store Data Document Type">
-                                    <drop-down><list-options list="storeDataDocumentTypeList.findAll{!storeDataDocumentList.storeDataDocumentTypeEnumId.contains(it.enumId)}" key="${enumId}" text="${enumId}: ${description ?: ''}"/></drop-down>
+                                <field name="storeDocumentTypeEnumId"><default-field title="Store Data Document Type">
+                                    <drop-down><list-options list="storeDataDocumentTypeList.findAll{!storeDataDocumentList.storeDocumentTypeEnumId.contains(it.enumId)}" key="${enumId}" text="${enumId}: ${description ?: ''}"/></drop-down>
                                 </default-field></field>
                                 <field name="dataDocumentId"><default-field title="Data Document">
                                     <drop-down><list-options list="dataDocumentList" key="${dataDocumentId}" text="${dataDocumentId} - ${documentName}"/></drop-down>
@@ -421,7 +421,7 @@ along with this software (see the LICENSE.md file). If not, see
                         <box-body>
                             <form-list name="StoreDataDocumentForm" list="storeDataDocumentList" transition="updateStoreDataDocument">
                                 <field name="productStoreId"><default-field><hidden/></default-field></field>
-                                <field name="storeDataDocumentTypeEnumId"><default-field title="Store Data Document Type"><display-entity
+                                <field name="storeDocumentTypeEnumId"><default-field title="Store Data Document Type"><display-entity
                                         entity-name="moqui.basic.Enumeration"/></default-field></field>
                                 <field name="dataDocumentId"><default-field title="Data Document">
                                     <drop-down><list-options list="dataDocumentList" key="${dataDocumentId}" text="${dataDocumentId} - ${documentName}"/></drop-down>


### PR DESCRIPTION
Add Category Identification Section to EditCategory, Add Other Identification Section to EditProduct, Add Store Data Documents Section to EditProductStore.

Related to:
- https://github.com/moqui/mantle-udm/pull/92
- https://github.com/moqui/mantle-usl/pull/189
- https://github.com/moqui/PopCommerce/pull/56

As discussed in 
- https://forum.moqui.org/t/productstore-datadocument-options/303/2
- https://forum.moqui.org/t/moqui-slug-data-model-handling/289/12