### PR TITLE
Set Default Project based on task root Work Effort

### DIFF
--- a/screen/SimpleScreens/Task/EditRelated.xml
+++ b/screen/SimpleScreens/Task/EditRelated.xml
@@ -66,8 +66,8 @@ along with this software (see the LICENSE.md file). If not, see
                             </entity-find>
                         </entity-options>
                     </drop-down></default-field></field>
-                    <field name="rootWorkEffortId"><default-field title="Project"><drop-down>
-                        <entity-options key="${workEffortId}" text="${workEffortId}: ${workEffortName}">
+                    <field name="rootWorkEffortId" from="task?.rootWorkEffortId"><default-field title="Project"><drop-down>
+                        <entity-options key="${workEffortId}" text="${workEffortId}: ${workEffortName}" >
                             <entity-find entity-name="WorkEffortAndParty">
                                 <econditions combine="or">
                                     <econdition field-name="visibilityEnumId" operator="in" value="WevGeneral,WevAllUsers"/>
@@ -93,7 +93,7 @@ along with this software (see the LICENSE.md file). If not, see
                     <field name="workEffortId"><default-field><hidden/></default-field></field>
                     <field name="toWorkEffortId" from="workEffortId"><default-field><hidden/></default-field></field>
 
-                    <field name="rootWorkEffortId"><default-field title="Project"><drop-down>
+                    <field name="rootWorkEffortId" from="task?.rootWorkEffortId"><default-field title="Project"><drop-down>
                         <entity-options key="${workEffortId}" text="${workEffortId}: ${workEffortName}">
                             <entity-find entity-name="WorkEffortAndParty">
                                 <econditions combine="or">


### PR DESCRIPTION
Set the default selected project to the current project's Root Work Effort in the "Add Related To" and Add Related From" dialogs. If there is a project set on the Task then defaulting the selection to the Task's project is more convenient for the user.