### PR TITLE
Related new task dialog

### DIFF
--- a/screen/SimpleScreens/Task/EditRelated.xml
+++ b/screen/SimpleScreens/Task/EditRelated.xml
@@ -28,6 +28,16 @@ along with this software (see the LICENSE.md file). If not, see
     </transition>
     <transition name="taskSummary"><default-response url="../TaskSummary"/></transition>
 
+    <transition name="createTask">
+        <actions>
+            <service-call name="mantle.work.TaskServices.create#Task" in-map="context + [workEffortId:null]" out-map="context"/>
+            <service-call name="create#mantle.work.effort.WorkEffortAssoc" in-map="context + [workEffortId:fromWorkEffortId, toWorkEffortId:workEffortId]"/>
+        </actions>
+        <default-response url="../TaskSummary"/></transition>
+    <transition name="getProjectParties">
+        <service-call name="mantle.work.ProjectServices.get#ProjectParties" web-send-json-response="resultList"/>
+        <default-response type="none"/>
+    </transition>
     <transition name="getProjectTasks">
         <actions>
             <service-call name="mantle.work.ProjectServices.get#ProjectTasks" in-map="context" out-map="context"/>
@@ -35,6 +45,11 @@ along with this software (see the LICENSE.md file). If not, see
         </actions>
         <default-response type="none"/>
     </transition>
+    <transition name="getProjectMilestones">
+        <service-call name="mantle.work.ProjectServices.get#ProjectMilestones" web-send-json-response="resultList"/>
+        <default-response type="none"/>
+    </transition>
+    <transition-include name="getTaskList" location="component://SimpleScreens/template/work/WorkTransitions.xml"/>
 
     <actions>
         <set field="mainWorkEffortId" from="workEffortId"/>
@@ -124,6 +139,90 @@ along with this software (see the LICENSE.md file). If not, see
                     </drop-down></default-field></field>
 
                     <field name="submitButton"><default-field title="Add Related"><submit/></default-field></field>
+                </form-single>
+            </container-dialog>
+            <container-dialog id="NewTaskContainer" button-text="New Related To Task">
+                <form-single name="NewTaskForm" transition="createTask">
+                    <field name="workEffortId"><default-field><hidden/></default-field></field>
+                    <field name="fromWorkEffortId" from="workEffortId"><default-field><hidden/></default-field></field>
+
+                    <field name="workEffortAssocTypeEnumId"><default-field title="Type"><drop-down>
+                        <entity-options key="${enumId}" text="${description}">
+                            <entity-find entity-name="moqui.basic.Enumeration">
+                                <econditions combine="or">
+                                    <econdition field-name="enumId" value="WeatRelatesTo"/>
+                                    <econdition field-name="parentEnumId" value="WeatRelatesTo"/>
+                                </econditions>
+                                <order-by field-name="description"/>
+                            </entity-find>
+                        </entity-options>
+                    </drop-down></default-field></field>
+                    <field name="rootWorkEffortId"><default-field title="Project"><drop-down>
+                        <entity-options key="${workEffortId}" text="${workEffortId}: ${workEffortName}">
+                            <entity-find entity-name="WorkEffortAndParty">
+                                <econditions combine="or">
+                                    <econdition field-name="visibilityEnumId" operator="in" value="WevGeneral,WevAllUsers"/>
+                                    <econditions><date-filter/><econdition field-name="partyId" from="ec.user.userAccount.partyId"/></econditions>
+                                </econditions>
+                                <econdition field-name="workEffortTypeEnumId" value="WetProject"/>
+                                <order-by field-name="workEffortId"/>
+                            </entity-find>
+                        </entity-options>
+                    </drop-down></default-field></field>
+
+                    <field name="milestoneWorkEffortId"><default-field title="Milestone">
+                        <drop-down allow-empty="true">
+                            <dynamic-options transition="getProjectMilestones" value-field="workEffortId" label-field="milestoneLabel">
+                                <depends-on field="rootWorkEffortId"/></dynamic-options>
+                        </drop-down>
+                    </default-field></field>
+                    <field name="parentWorkEffortId"><default-field title="Parent Task">
+                        <drop-down allow-empty="true">
+                            <dynamic-options transition="getTaskList" min-length="2" server-search="true" depends-optional="true">
+                                <depends-on field="rootWorkEffortId"/></dynamic-options>
+                        </drop-down>
+                        <!--
+                        <drop-down>
+                            <dynamic-options transition="getProjectTasks" value-field="workEffortId" label-field="taskLabel">
+                                <depends-on field="rootWorkEffortId"/></dynamic-options>
+                        </drop-down>
+                        -->
+                    </default-field></field>
+                    <field name="assignToPartyId"><default-field title="Assign To">
+                        <drop-down no-current-selected-key="${ec.user.userAccount.partyId}" allow-empty="true">
+                            <dynamic-options transition="getProjectParties" value-field="partyId" label-field="name"
+                                             depends-optional="true" server-search="true" min-length="0" parameter-map="[addOptional:'false']">
+                                <depends-on field="rootWorkEffortId"/></dynamic-options>
+                        </drop-down>
+                    </default-field></field>
+                    <field name="workEffortName"><default-field title="Task Name"><text-line/></default-field></field>
+                    <field name="priority"><default-field>
+                        <drop-down no-current-selected-key="5">
+                            <option key="1"/><option key="2"/><option key="3"/><option key="4"/><option key="5"/>
+                            <option key="6"/><option key="7"/><option key="8"/><option key="9"/></drop-down>
+                    </default-field></field>
+                    <field name="purposeEnumId"><default-field title="Purpose">
+                        <drop-down no-current-selected-key="WepTask">
+                            <entity-options key="${enumId}" text="${description}">
+                                <entity-find entity-name="moqui.basic.Enumeration">
+                                    <econdition field-name="enumTypeId" value="WorkEffortPurpose"/>
+                                    <econdition field-name="parentEnumId" value="WetTask"/>
+                                    <order-by field-name="description"/>
+                                </entity-find>
+                            </entity-options>
+                        </drop-down>
+                    </default-field></field>
+                    <field name="statusId"><default-field title="Status">
+                        <widget-template-include location="component://webroot/template/screen/BasicWidgetTemplates.xml#statusDropDown">
+                            <set field="statusTypeId" value="WorkEffort"/></widget-template-include>
+                    </default-field></field>
+                    <field name="estimatedCompletionDate">
+                        <default-field title="Due Date"><date-time type="date" format="yyyy-MM-dd"/></default-field>
+                    </field>
+                    <field name="estimatedWorkTime"><default-field title="Estimated Hours">
+                        <text-line size="5"/></default-field></field>
+                    <field name="description"><default-field title="Description"><text-area rows="10" cols="60"/></default-field></field>
+                    <field name="submitButton"><default-field title="Create"><submit/></default-field></field>
                 </form-single>
             </container-dialog>
         </container>

--- a/template/product/ProductTransitions.xml
+++ b/template/product/ProductTransitions.xml
@@ -241,19 +241,21 @@ along with this software (see the LICENSE.md file). If not, see
                     <econdition field-name="classEnumId" ignore-if-empty="true"/>
                     <econdition field-name="quantityOnHandTotal" operator="not-equals" from="0.0" ignore="!excludeZeroQohBool"/>
                     <econditions combine="or">
+                        <!-- TODO for large Asset tables consider removing leading percent wildcard, term will need to match leading characters but much faster -->
                         <econdition field-name="assetId" operator="like" value="%${term}%"/>
                         <econdition field-name="assetName" operator="like" value="%${term}%" ignore-case="true"/>
                         <econdition field-name="lotId" operator="like" value="%${term}%"/>
                         <econdition field-name="lotNumber" operator="like" value="%${term}%" ignore-case="true"/>
+                        <econdition field-name="serialNumber" operator="like" value="%${term}%" ignore-case="true"/>
                         <econdition field-name="pseudoId" operator="like" value="%${term}%" ignore-case="true" ignore="productId"/>
                         <econdition field-name="productName" operator="like" value="%${term}%" ignore-case="true" ignore="productId"/>
                     </econditions>
-                    <select-field field-name="assetId,assetName,availableToPromiseTotal,quantityOnHandTotal,lotId,lotNumber,pseudoId,productName"/>
+                    <select-field field-name="assetId,assetName,availableToPromiseTotal,quantityOnHandTotal,lotId,lotNumber,serialNumber,pseudoId,productName"/>
                     <order-by field-name="${assetOrderBy ?: '-receivedDate'}"/>
                 </entity-find>
                 <script>
                     def outList = []
-                    for (asset in assetList) outList.add([value:asset.assetId, label:"${ec.resource.expand('AssetNameTemplate','',asset)} - ${ec.resource.expand('ProductNameTemplate','',asset)} ATP ${ec.l10n.format(asset.availableToPromiseTotal, '#,##0.###')} QOH ${ec.l10n.format(asset.quantityOnHandTotal, '#,##0.###')}${asset.lotId || asset.lotNumber ? ' Lot ' + (asset.lotNumber ?: asset.lotId) : ''}".toString()])
+                    for (asset in assetList) outList.add([value:asset.assetId, label:"${ec.resource.expand('AssetNameTemplate','',asset)} - ${ec.resource.expand('ProductNameTemplate','',asset)} ATP ${ec.l10n.format(asset.availableToPromiseTotal, '#,##0.###')} QOH ${ec.l10n.format(asset.quantityOnHandTotal, '#,##0.###')}${asset.lotId || asset.lotNumber ? ' Lot ' + (asset.lotNumber ?: asset.lotId) : ''}${asset.serialNumber ? ' SN ' + asset.serialNumber : ''}".toString()])
                     ec.web.sendJsonResponse(outList)
                 </script>
             </else></if>


### PR DESCRIPTION
When wanting to add a Task related to the current Task, the current work flow is:
Start at the EditRelated screen for Task 1
1. Go to FindTask
2. Fill out the Create Task Dialog (create Task 2)
3. Find Task 1 in Find Task
4. Go to EditRelated screen
5. Fill out the Add Related To Dialog (relate Task 1 to Task 2)

This PR's contribution is to add a button for doing this with one dialog where the work flow is:
Start at the EditRelated screen for Task 1
1. Fill out the Create Related To Task (create Task 2 and relate Task 1 to Task 2)
